### PR TITLE
Feat/timeout hack - setValueNoAck()

### DIFF
--- a/EmberClient/EmberClient.js
+++ b/EmberClient/EmberClient.js
@@ -626,6 +626,11 @@ class EmberClient extends EventEmitter {
      * @returns {Promise<TreeNode>}
      */
     setValueNoAck(node, value) {
+        // This function immediately finish & resolve so we can't get any timeouts ever
+        // This is a pretty ugly hack, but it doesn't look to bring
+        // any negative consequences regarding the execution and resolving of other
+        // functions. It´s needed this because if the node already has the value we are
+        // setting it too, it will cause a timeout.
         return new Promise((resolve, reject) => {
             if (!node.isParameter()) {
                 reject(new Errors.EmberAccessError('not a Parameter'));
@@ -642,6 +647,7 @@ class EmberClient extends EventEmitter {
 
                 this._finishRequest();
                 this._callback = null;
+                return resolve(node)
             }});
         })
     }

--- a/EmberClient/EmberClient.js
+++ b/EmberClient/EmberClient.js
@@ -621,6 +621,51 @@ class EmberClient extends EventEmitter {
 
     /**
      * 
+     * @param {TreeNode} node 
+     * @param {string|number} value
+     * @returns {Promise<TreeNode>}
+     */
+    setValueWithHacksaw(node, value) {
+        return new Promise((resolve, reject) => {
+            if (!node.isParameter()) {
+                reject(new Errors.EmberAccessError('not a Parameter'));
+            }
+            else {
+                this.addRequest({node: node, func: error => {
+                    if (error) {
+                        this._finishRequest();
+                        reject(error);
+                        return;
+                    }
+    
+                    this._callback = (error, node) => {
+                        // this._finishRequest();
+                        // this._callback = null;
+                        if (error) {
+                            reject(error);
+                        }
+                        else {
+                            
+                            // resolve(node);
+                        }
+                    };
+                    winston.debug('setValue sending ...', node.getPath(), value);
+                    this._client.sendBERNode(node.setValue(value));
+
+                    // We now immediately finish & resolve so we can't get any timeouts ever
+                    // This is a pretty ugly hack, but as far as I can tell it doesn't bring
+                    // any negative consequences regarding the execution and resolving of other
+                    // functions. We need this because if the node already has the value we are
+                    // setting it too, it will cause a timeout.
+                    this._finishRequest();
+                    this._callback = null;
+                }});
+            }
+        });
+    }
+   
+    /**
+     * 
      * @param {TreeNode} qnode 
      * @param {function} callback
      * @returns {Promise}

--- a/EmberClient/EmberClient.js
+++ b/EmberClient/EmberClient.js
@@ -625,43 +625,25 @@ class EmberClient extends EventEmitter {
      * @param {string|number} value
      * @returns {Promise<TreeNode>}
      */
-    setValueWithHacksaw(node, value) {
+    setValueNoAck(node, value) {
         return new Promise((resolve, reject) => {
             if (!node.isParameter()) {
                 reject(new Errors.EmberAccessError('not a Parameter'));
+                return;
             }
-            else {
-                this.addRequest({node: node, func: error => {
-                    if (error) {
-                        this._finishRequest();
-                        reject(error);
-                        return;
-                    }
-    
-                    this._callback = (error, node) => {
-                        // this._finishRequest();
-                        // this._callback = null;
-                        if (error) {
-                            reject(error);
-                        }
-                        else {
-                            
-                            // resolve(node);
-                        }
-                    };
-                    winston.debug('setValue sending ...', node.getPath(), value);
-                    this._client.sendBERNode(node.setValue(value));
-
-                    // We now immediately finish & resolve so we can't get any timeouts ever
-                    // This is a pretty ugly hack, but as far as I can tell it doesn't bring
-                    // any negative consequences regarding the execution and resolving of other
-                    // functions. We need this because if the node already has the value we are
-                    // setting it too, it will cause a timeout.
+            this.addRequest({node: node, func: error => {
+                if (error) {
                     this._finishRequest();
-                    this._callback = null;
-                }});
-            }
-        });
+                    reject(error);
+                    return;
+                }
+                winston.debug('setValue sending ...', node.getPath(), value);
+                this._client.sendBERNode(node.setValue(value));
+
+                this._finishRequest();
+                this._callback = null;
+            }});
+        })
     }
    
     /**


### PR DESCRIPTION
Added: setValueNoAck() function
This Hack solves timeout problems when setting the same value twice as seen on Lawo desks. (and probably other equipment)
It's based on a hack in the NRKNO fork and gives the speed needed on Lawo desks, to do a realtime fade.
In the NRKNO forks it's called setValueWithHacksaw() but after conversation with them we agreed on setValueNoAck()
