### PR TITLE
Fix when a node has no childs

### DIFF
--- a/src/client/ember-client.ts
+++ b/src/client/ember-client.ts
@@ -264,26 +264,28 @@ export class EmberClient extends EventEmitter {
                         throw new InvalidEmberResponseError(`getDirectory ${requestedPath}`);
                     }
                 } else if (node.getElementByPath(requestedPath) != null) {
-                    const resolved = node.getElementByPath(requestedPath)!;
-                    this.logger?.log(ClientLogs.GETDIRECTORY_RESPONSE(resolved));
+                    const resolved = node.getElementByPath(requestedPath);
+                    if (resolved != null) {
+                        this.logger?.log(ClientLogs.GETDIRECTORY_RESPONSE(resolved));
 
-                    if (resolved.isStream && resolved.isStream()) {
-                        const streamIdentifier = (resolved as Parameter).streamIdentifier;
-                        const streamEntry = this._streams.getEntry(streamIdentifier);
-                        if (streamEntry != null && streamEntry.value !== requestedPath) {
-                            // Duplicate Stream Entry.
-                            this.logger?.log(ClientLogs.DUPLICATE_STREAM_IDENTIFIER(streamIdentifier, requestedPath, streamEntry.value));
-                        } else {
-                            this.logger?.log(ClientLogs.ADDING_STREAM_IDENTIFIER(streamIdentifier, requestedPath));
-                            this._streams.addEntry(
-                                new StreamEntry(
-                                    streamIdentifier,
-                                    requestedPath
-                                )
-                            );
+                        if (resolved.isStream && resolved.isStream()) {
+                            const streamIdentifier = (resolved as Parameter).streamIdentifier;
+                            const streamEntry = this._streams.getEntry(streamIdentifier);
+                            if (streamEntry != null && streamEntry.value !== requestedPath) {
+                                // Duplicate Stream Entry.
+                                this.logger?.log(ClientLogs.DUPLICATE_STREAM_IDENTIFIER(streamIdentifier, requestedPath, streamEntry.value));
+                            } else {
+                                this.logger?.log(ClientLogs.ADDING_STREAM_IDENTIFIER(streamIdentifier, requestedPath));
+                                this._streams.addEntry(
+                                    new StreamEntry(
+                                        streamIdentifier,
+                                        requestedPath
+                                    )
+                                );
+                            }
                         }
+                        return resolved; // return the element, not the response root
                     }
-                    return resolved; // return the element, not the response root        } else if (node.getElementByPath(requestedPath) != null) {
                 } else {
                     const nodeElements = node?.getChildren();
                     if (nodeElements != null &&

--- a/src/client/ember-client.ts
+++ b/src/client/ember-client.ts
@@ -264,9 +264,11 @@ export class EmberClient extends EventEmitter {
                         throw new InvalidEmberResponseError(`getDirectory ${requestedPath}`);
                     }
                 } else if (node.getElementByPath(requestedPath) != null) {
-                    this.logger?.log(ClientLogs.GETDIRECTORY_RESPONSE(node));
-                    if (node.isStream()) {
-                        const streamIdentifier = (node as Parameter).streamIdentifier;
+                    const resolved = node.getElementByPath(requestedPath)!;
+                    this.logger?.log(ClientLogs.GETDIRECTORY_RESPONSE(resolved));
+
+                    if (resolved.isStream && resolved.isStream()) {
+                        const streamIdentifier = (resolved as Parameter).streamIdentifier;
                         const streamEntry = this._streams.getEntry(streamIdentifier);
                         if (streamEntry != null && streamEntry.value !== requestedPath) {
                             // Duplicate Stream Entry.
@@ -281,7 +283,7 @@ export class EmberClient extends EventEmitter {
                             );
                         }
                     }
-                    return node; // make sure the info is treated before going to next request.
+                    return resolved; // return the element, not the response root        } else if (node.getElementByPath(requestedPath) != null) {
                 } else {
                     const nodeElements = node?.getChildren();
                     if (nodeElements != null &&


### PR DESCRIPTION
When en element of type Node has no childs, the root of the node is returned by getDirectoryAsync. This generates an infinite loop where the same function is called. By returning the element and not the root, this properly detects that there is no child and finishes that branch of the tree.

Here's the log displayed in a loop:
```
1763853435553 - DEBUG - EXPANDING_NODE Expanding node 1.2
1763853435553 - DEBUG - MAKING_REQUEST Making new request
1763853435553 - DEBUG - GETDIRECTORY_SENDING_QUERY Sending GetDirectory query 1.2
1763853435559 - DEBUG - EMBER_MESSAGE_RECEIVED Received Ember Message
1763853435559 - DEBUG - GETDIRECTORY_RESPONSE getDirectory response <ref *1> TreeNode {
  _parent: null,
  _subscribers: Set(0) {},
  elements: Map(1) {
    '1.2' => QualifiedNode {
      _parent: [Circular *1],
      _subscribers: Set(0) {},
      _path: '1.2',
      _seqID: 106,
      _contents: [NodeContents]
    }
  }
}
```

And here's what is returned with the change:
```
1763853592062 - DEBUG - EXPANDING_NODE Expanding node 1.2
1763853592062 - DEBUG - MAKING_REQUEST Making new request
1763853592062 - DEBUG - GETDIRECTORY_SENDING_QUERY Sending GetDirectory query 1.2
1763853592068 - DEBUG - EMBER_MESSAGE_RECEIVED Received Ember Message
1763853592068 - DEBUG - GETDIRECTORY_RESPONSE getDirectory response <ref *1> QualifiedNode {
  _parent: TreeNode {
    _parent: null,
    _subscribers: Set(0) {},
    elements: Map(1) { '1.2' => [Circular *1] }
  },
  _subscribers: Set(0) {},
  _path: '1.2',
  _seqID: 106,
  _contents: NodeContents { identifier: 'ios', description: '', isOnline: true }
}
```

I also attached the generated json. I only could get it with the fix as the json file is saved at the end and because of the loop, it never ends.

The fix is based on version3 branch.

[fix_loop_when_nochild.json](https://github.com/user-attachments/files/23692242/fix_loop_when_nochild.json)
